### PR TITLE
Add STP system package to macos dependencies

### DIFF
--- a/.github/workflows/install_dependencies_testsuite_macos.sh
+++ b/.github/workflows/install_dependencies_testsuite_macos.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-brew install ccache deja-gnu icarus-verilog
+brew install ccache deja-gnu icarus-verilog stp


### PR DESCRIPTION
In relation to [bsc#563](https://github.com/B-Lang-org/bsc/pull/563), the system package for STP needs to be installed for the CI to pass.

This PR can be merged unconditionally, as adding dependencies is at most unnecessary, but does not affect the current version. It does however enable BSC to be built and run using the system package.