### PR TITLE
GitHub CI: Update the OS and action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download bsc
         shell: bash
@@ -35,16 +35,16 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-11, macos-12, macos-13 ]
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download bsc
         shell: bash
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ".github/workflows/get_latest_bsc.sh 'macos-10.13+' "
+        run: ".github/workflows/get_latest_bsc.sh ${{ matrix.os }} "
 
       - name: Build
         run: |
@@ -61,11 +61,11 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         shell: bash
         run: "sudo .github/workflows/install_dependencies_doc_ubuntu.sh"
@@ -82,11 +82,11 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-11, macos-12, macos-13 ]
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         shell: bash
         run: ".github/workflows/install_dependencies_doc_macos.sh"
@@ -106,13 +106,13 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: build-ubuntu
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         shell: bash
@@ -134,7 +134,7 @@ jobs:
           cp -r testing/bsc.bdw ../bsc-testsuite/testsuite/
 
       - name: Download bdw
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.os }} build
       - name: Install bdw
@@ -144,7 +144,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -196,7 +196,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz
@@ -204,12 +204,12 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-11, macos-12, macos-13 ]
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
     needs: build-macos
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         shell: bash
@@ -220,7 +220,7 @@ jobs:
         shell: bash
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ".github/workflows/get_latest_bsc.sh 'macos-10.13+' "
+        run: ".github/workflows/get_latest_bsc.sh ${{ matrix.os }} "
 
       # This ought to be downloaded at the same version as BSC?
       - name: Download testsuite
@@ -231,7 +231,7 @@ jobs:
           cp -r testing/bsc.bdw ../bsc-testsuite/testsuite/
 
       - name: Download bdw
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.os }} build
       - name: Install bdw
@@ -241,7 +241,7 @@ jobs:
       # in the key so that a new cache file is generated after every
       # successful build, and have the restore-key use the most recent.
       - name: CCache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ GITHUB.WORKSPACE }}/ccache
           key: ${{ matrix.os }}-ccache-${{ github.sha }}
@@ -289,7 +289,7 @@ jobs:
       # Save test logs on failure so we can diagnose
       - name: Archive test logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-logs-${{ matrix.os }}
           path: logs.tar.gz


### PR DESCRIPTION
The CI is broken because it is attempting to use runners (for older OS versions) that are no longer available.