### PR TITLE
GitHub CI: Update the OS matrix and rename YAML file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -35,7 +35,7 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
@@ -63,7 +63,7 @@ jobs:
   build-doc-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -112,7 +112,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -213,7 +213,7 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-12, macos-13, macos-14 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}

--- a/.github/workflows/install_dependencies_doc_macos.sh
+++ b/.github/workflows/install_dependencies_doc_macos.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-brew install mactex-no-gui
+brew install texlive


### PR DESCRIPTION
Add ubuntu-24.04, remove macos-11, and add macos-14. The Action versions (e.g. checkout@v4) are up to date, so no change is needed there. Renamed the CI YAML file to indicate that it is the top-level CI file (matching the naming structure used in the BSC repo).

For building of the docs, the package install on macOS is changed to install `texlive` instead of `mactex-no-gui` (which is a pre-built version of `texlive` that includes everything).  This saves space (working around a space issue with GitHub's recent macos-14 VM image) and turns out to run faster too.  The same change was made in the BSC repo.

This closes #16.