### PR TITLE
Update macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   build-macOS:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
       fail-fast: false
     name: "Build ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}
@@ -86,7 +86,7 @@ jobs:
   build-doc-macOS:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
       fail-fast: false
     name: "Build doc: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -213,7 +213,7 @@ jobs:
   test-macOS:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
       fail-fast: false
     name: "Test ${{ matrix.os }}"
     runs-on: ${{ matrix. os }}

--- a/.github/workflows/install_dependencies_doc_macos.sh
+++ b/.github/workflows/install_dependencies_doc_macos.sh
@@ -1,3 +1,15 @@
 #!/usr/bin/env bash
 
+brew update
+
+# The install of 'texlive' may cause the install of a newer version of
+# 'python', which could fail because it cannot overwrite links for
+# older versions, due to an issue with the GitHub runner images:
+#   https://github.com/actions/runner-images/issues/9966
+# To avoid that, we unlink and install with overwrite:
+#
+for python_package in $(brew list | grep python@); do
+    brew unlink ${python_package} && brew link --overwrite ${python_package}
+done
+
 brew install texlive


### PR DESCRIPTION
This removes the macos-12 target (deprecated) and adds macos-15 (beta).

It also works around an issue on GitHub runners for macOS, that have a pre-installed python whose links interfere with the install of python by Homebrew -- which can happen if we try to install something that has python as a dependency, at a version newer than what is pre-installed. There is an open issue for this, 9966 in the actions/runner-images repo.